### PR TITLE
Long jump

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -27,12 +27,7 @@ Start:
 
 restart:
     ; jump to init function based on jump table
-    lda #$00
-    xba
-    lda CUR_SEL
-    asl
-    tax
-    jsr (init_jump_table, X)
+    jsl prepare_jump_init
 
 init_end:
     lda #$0F
@@ -81,21 +76,68 @@ VBlank:
     rti
 
     ; jump to update function
-+   lda #$00
++   jsl prepare_jump_update
+    rti
+
+; jump table with rti trick to emulate long jump to subroutine witn index
+; jsl [jump_table, x]
+prepare_jump_init:
+    ; push program bank
+    lda #0
     xba
     lda CUR_SEL
+    tax
+    lda init_jump_table_bank.l, x
+    pha
+    ; push program counter
+    rep #$20 ; 16bit a
+    lda CUR_SEL
+    and #$00ff
     asl
     tax
-    jsr (update_jump_table, X)
+    lda init_jump_table.l, x
+    pha
+    sep #$20
+    ; push processor status
+    php
+    ; fake rti, emulate long jump with index
+    rti
+
+prepare_jump_update:
+    ; push program bank
+    lda #0
+    xba
+    lda CUR_SEL
+    tax
+    lda update_jump_table_bank.l, x
+    pha
+    ; push program counter
+    rep #$20 ; 16bit a
+    lda CUR_SEL
+    and #$00ff
+    asl
+    tax
+    lda update_jump_table.l, x
+    pha
+    sep #$20
+    ; push processor status
+    php
+    ; fake rti, emulate long jump with index
     rti
 
 init_jump_table:
     .DW menu.init
     .DW waterfall.init
+init_jump_table_bank:
+    .DB :menu.init
+    .DB :waterfall.init
 
 update_jump_table:
     .DW menu.update
     .DW waterfall.update
+update_jump_table_bank:
+    .DB :menu.update
+    .DB :waterfall.update
 
 dummy:
     rtl

--- a/src/main.asm
+++ b/src/main.asm
@@ -22,8 +22,7 @@ Start:
     sep #%00100000  ;8 bit ab
 
     ; initialize variable
-    lda #1
-    sta CUR_SEL
+    stz CUR_SEL
 
 restart:
     ; jump to init function based on jump table

--- a/src/menu.asm
+++ b/src/menu.asm
@@ -155,7 +155,7 @@ init:
     ; initialize variable
     stz CURSOR_IDX
 
-    rts
+    rtl
 
 ; run during vblank
 update:
@@ -172,7 +172,7 @@ update:
     lda CURSOR_IDX
     sta CUR_SEL
     lda #-1
-    rts
+    rtl
 
     ; up button
 +   lda INPUT_PRESSED+1
@@ -188,7 +188,7 @@ update:
 +   bit #%00000100
     bne +
 ret lda #0
-    rts
+    rtl
 +   ; down button pressed
     lda CURSOR_IDX
     ina
@@ -252,7 +252,7 @@ scroll_bot: ; idx = count-8~count-1
     xba
     sta $210e
     lda #0
-    rts
+    rtl
 
 scroll_mid:
     ; update menu entry text
@@ -367,7 +367,7 @@ scroll_mid:
     lda #-1
     sta $210e
     lda #0
-    rts
+    rtl
 
 .ENDS
 

--- a/src/waterfall.asm
+++ b/src/waterfall.asm
@@ -94,7 +94,7 @@ init:
     stz BG2_XOFF
     stz BG2_YOFF
     sep #$20        ; 8bit a
-    rts
+    rtl
 
 ; run during vblank
 update:
@@ -131,7 +131,7 @@ update:
     sta $2110
 
     lda #0
-    rts
+    rtl
 
 .ENDS
 


### PR DESCRIPTION
use long jump when jumping to init and update functions from main, allowing init and update code to be located in any bank (rather than being limited to bank 0)